### PR TITLE
adding tag support

### DIFF
--- a/virtual_machine/vsphere_virtual_machine/linux_cloning/datasource.tf
+++ b/virtual_machine/vsphere_virtual_machine/linux_cloning/datasource.tf
@@ -29,11 +29,13 @@ data "vsphere_virtual_machine" "template" {
   datacenter_id = data.vsphere_datacenter.dc.id
 }
 
-#data "vsphere_tag_category" "category" {
-#  name = var.tag_category
-#}
+data "vsphere_tag_category" "tag_categories" {
+  count = length(var.vm_tags) #for each tag retreive its category
+  name = var.vm_tags[count.index].category_name
+}
 
-#data "vsphere_tag" "tag" {
-#  name        = var.vm_tags
-#  category_id = data.vsphere_tag_category.category.id
-#}
+data "vsphere_tag" "tags" {
+  count = length(var.vm_tags) #match the data to the number of tag
+  name = var.vm_tags[count.index].tag_name
+  category_id = data.vsphere_tag_category.tag_categories[count.index].id
+}

--- a/virtual_machine/vsphere_virtual_machine/linux_cloning/variables.tf
+++ b/virtual_machine/vsphere_virtual_machine/linux_cloning/variables.tf
@@ -24,18 +24,25 @@ variable "cust_trigramm" {
 }
 
 ### Metadata
-variable "tag_name" {
-  type = string
-  default = true
-  description = "vSphere tag for this VM"
-  nullable = true
-}
+variable "vm_tags" {
+  type = list(object({
+    category_name = string
+    tag_name = string
+  }))
+  default = [{
+      category_name = "provisioner"
+      tag_name = "terraform"
 
-variable "tag_category" {
-  type = string
-  default = ""
-  description = "vSphere tag category"
-  nullable = true
+    },
+    {
+      category_name = "status"
+      tag_name = "prod"
+    },
+    {
+      category_name = "customer"
+      tag_name = "ttv"
+    }
+  ]
 }
 
 variable "custom_attribute" {

--- a/virtual_machine/vsphere_virtual_machine/linux_cloning/vm_resources_creation.tf
+++ b/virtual_machine/vsphere_virtual_machine/linux_cloning/vm_resources_creation.tf
@@ -3,13 +3,9 @@ resource "vsphere_virtual_machine" "vm_linux" {
   resource_pool_id = var.vsphere_resource_pool != "" ? data.vsphere_resource_pool.resource_pool[0].id : data.vsphere_compute_cluster.cls_hosts.resource_pool_id
   datastore_id = data.vsphere_datastore.datastore.id
   folder = "${var.vsphere_folder}"
-  #dynamic "tags" {
-  #  for_each = var.vm_tags
-  #  content {
-  #    name = var.tag_name
-  #    category = var.tag_category
-  #  }
-  #}
+  tags = [
+    for tag in data.vsphere_tag.tags : tag.id
+  ]
 
   name                 = var.vm_name
   firmware = var.vm_firmware


### PR DESCRIPTION
The module vm_linux now allows to add multiple single tags to a single VM
Number of tags can change between VM

Just have to override the defaults

```
variable "vm_tags" {
  type = list(object({
    category_name = string
    tag_name = string
  }))
  default = [{
      category_name = "provisioner"
      tag_name = "terraform"

    },
    {
      category_name = "status"
      tag_name = "prod"
    },
    {
      category_name = "customer"
      tag_name = "ttv"
    }
  ]
}
```