### PR TITLE
add multiple nics

### DIFF
--- a/virtual_machine/vsphere_virtual_machine/linux_cloning/datasource.tf
+++ b/virtual_machine/vsphere_virtual_machine/linux_cloning/datasource.tf
@@ -9,8 +9,8 @@ data "vsphere_compute_cluster" "cls_hosts" {
 }
 
 data "vsphere_resource_pool" "resource_pool" {
-  count = length(var.vsphere_resource_pool) > 0 ? 1 : 0 
-  name = var.vsphere_resource_pool
+  count         = length(var.vsphere_resource_pool) > 0 ? 1 : 0
+  name          = var.vsphere_resource_pool
   datacenter_id = data.vsphere_datacenter.dc.id
 }
 
@@ -19,8 +19,9 @@ data "vsphere_datastore" "datastore" {
   datacenter_id = data.vsphere_datacenter.dc.id
 }
 
-data "vsphere_network" "network" {
-  name          = var.vsphere_network
+data "vsphere_network" "networks" {
+  count         = length(var.vm_networks)
+  name          = var.vm_networks[count.index].network
   datacenter_id = data.vsphere_datacenter.dc.id
 }
 
@@ -31,11 +32,11 @@ data "vsphere_virtual_machine" "template" {
 
 data "vsphere_tag_category" "tag_categories" {
   count = length(var.vm_tags) #for each tag retreive its category
-  name = var.vm_tags[count.index].category_name
+  name  = var.vm_tags[count.index].category_name
 }
 
 data "vsphere_tag" "tags" {
-  count = length(var.vm_tags) #match the data to the number of tag
-  name = var.vm_tags[count.index].tag_name
+  count       = length(var.vm_tags) #match the data to the number of tag
+  name        = var.vm_tags[count.index].tag_name
   category_id = data.vsphere_tag_category.tag_categories[count.index].id
 }

--- a/virtual_machine/vsphere_virtual_machine/linux_cloning/variables.tf
+++ b/virtual_machine/vsphere_virtual_machine/linux_cloning/variables.tf
@@ -27,26 +27,26 @@ variable "cust_trigramm" {
 variable "vm_tags" {
   type = list(object({
     category_name = string
-    tag_name = string
+    tag_name      = string
   }))
   default = [{
-      category_name = "provisioner"
-      tag_name = "terraform"
+    category_name = "provisioner"
+    tag_name      = "terraform"
 
     },
     {
       category_name = "status"
-      tag_name = "prod"
+      tag_name      = "prod"
     },
     {
       category_name = "customer"
-      tag_name = "ttv"
+      tag_name      = "ttv"
     }
   ]
 }
 
 variable "custom_attribute" {
-  default = true
+  default     = true
   description = "custom attributes to pu on VM"
   nullable    = true
 }
@@ -65,10 +65,10 @@ variable "vsphere_cls_host" {
 }
 
 variable "vsphere_resource_pool" {
-  type = string
+  type        = string
   description = "Ressource pool for VM"
-  default = ""
-  nullable = true
+  default     = ""
+  nullable    = true
 }
 
 variable "vsphere_host" {
@@ -163,6 +163,29 @@ variable "vm_disks" {
   ]
 }
 
+variable "vm_networks" {
+  description = "Network interfaces to attach to the VM"
+  type = list(object(
+    {
+      network         = string
+      vm_ipv4_address = string
+      vm_ipv4_netmask = number
+
+    }
+  ))
+  default = [
+    {
+      network         = "VM Network"
+      vm_ipv4_address = "10.0.0.1"
+      vm_ipv4_netmask = 24
+    },
+    {
+      network         = "VM Network"
+      vm_ipv4_address = "10.0.0.1"
+      vm_ipv4_netmask = 24
+    }
+  ]
+}
 
 variable "vm_ipv4_ns" {
   description = "Name servers IP"
@@ -177,22 +200,10 @@ variable "vm_dns_suffixes" {
   nullable    = true
 }
 
-variable "vm_ipv4_address" {
-  type        = string
-  description = "IPv4 addresses for a vm"
-  default     = "192.168.1.1"
-}
-
 variable "vm_ipv4_gateway" {
   type        = string
   description = "IPv4 address of the Gateway"
   default     = "192.168.1.254"
-}
-
-variable "vm_ipv4_netmask" {
-  type        = string
-  description = "Netmask"
-  default     = 24
 }
 
 variable "vm_public_key" {

--- a/virtual_machine/vsphere_virtual_machine/linux_cloning/variables.tf
+++ b/virtual_machine/vsphere_virtual_machine/linux_cloning/variables.tf
@@ -83,12 +83,6 @@ variable "vsphere_ds" {
   default     = ""
 }
 
-variable "vsphere_network" {
-  type        = string
-  description = "Network name in vCenter"
-  default     = "VM Network"
-}
-
 variable "vsphere_folder" {
   type    = string
   default = "Discovered virtual machines"
@@ -174,11 +168,6 @@ variable "vm_networks" {
     }
   ))
   default = [
-    {
-      network         = "VM Network"
-      vm_ipv4_address = "10.0.0.1"
-      vm_ipv4_netmask = 24
-    },
     {
       network         = "VM Network"
       vm_ipv4_address = "10.0.0.1"


### PR DESCRIPTION
Added dynamics block to handle multiple nic sitting in different networks (vm network, pg, segments)

```
variable "vm_networks" {
  description = "Network interfaces to attach to the VM"
  type = list(object(
    {
      network         = string
      vm_ipv4_address = string
      vm_ipv4_netmask = number

    }
  ))
  default = [
    {
      network         = "VM Network"
      vm_ipv4_address = "10.0.0.1"
      vm_ipv4_netmask = 24
    }
  ]
}
```

Inside the clone
```
dynamic "network_interface" {
        for_each = var.vm_networks
        content {
          ipv4_address = network_interface.value.vm_ipv4_address
          ipv4_netmask = network_interface.value.vm_ipv4_netmask
        }
```

We loop through the datasource to get all the ID and create/remove nic accordingly.
This doesn't trigger vm recreation